### PR TITLE
backups: Add a systemd based backup method

### DIFF
--- a/.github/workflows/batesste-homesetup-backup-test.yml
+++ b/.github/workflows/batesste-homesetup-backup-test.yml
@@ -1,0 +1,49 @@
+name: batesste-homesetup
+on:
+  pull_request:
+    paths:
+      - 'backup/**'
+      - '!backup/README.md'
+
+jobs:
+  backup-test:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./backup
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Install mount-s3
+        run: |
+          wget https://s3.amazonaws.com/mountpoint-s3-release/latest/x86_64/mount-s3.deb
+          sudo apt-get install -y ./mount-s3.deb
+      - name: Create batesste-s3-backup.secrets file
+        run: |
+          echo "BLK_DEVICE=/dev/sda" > batesste-s3-backup.secrets
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.AWS_KEY }} >> batesste-s3-backup.secrets
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET }} >> batesste-s3-backup.secrets
+      - name: Install batesste-s3-backup systemd service and timer
+        run: |
+          sudo cp batesste-s3-backup /usr/local/bin/
+          sudo cp batesste-s3-backup.service /etc/systemd/system/
+          sudo cp batesste-s3-backup.timer /etc/systemd/system/
+          sudo mkdir -p /usr/local/share/batesste-s3-backup
+          sudo mv batesste-s3-backup.secrets /usr/local/share/batesste-s3-backup/
+      - name: Start up the batesste-s3-backup systemd service and timer
+        run: |
+          sudo systemctl daemon-reload
+          sudo systemctl enable batesste-s3-backup.timer
+          sudo systemctl start batesste-s3-backup.timer
+      - name: Run a local test as a sanity-check
+        run: |
+          dd if=/dev/urandom of=./test.data bs=1M count=10
+          sudo -E ./batesste-s3-backup
+        env:
+          FILE_MODE: true
+          BLK_DEVICE: test.data
+          MOUNT_POINT: /mnt/batesste-s3-backup
+          AWS_BUCKET: batesste-homelab-backups-ci
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *~
-dyndns/*.secrets
+*.secrets

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -15,7 +15,9 @@ homelab
 homesetup
 http
 IPv
+pigz
 md
+mountpoint
 README
 repo
 Speedtest

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ docker run -d --restart=always \
 See the referenced project for an example of the Prometheus scrape
 config and the Grafana dashboard.
 
+# Backups
+
+We enable a full disk backup of servers to AWS S3 buckets using
+[mountpoint][ref-mountpoint] and a systemd service. See the
+[backup README.md](./backup/README.md) for more information.
+
 [ref-aws-s3]: https://aws.amazon.com/s3/
 [ref-homebridge]: https://homebridge.io/
 [ref-ssl-certs]: https://www.kaspersky.com/resource-center/definitions/what-is-a-ssl-certificate
@@ -72,3 +78,4 @@ config and the Grafana dashboard.
 [ref-firefly]: https://docs.firefly-iii.org/
 [ref-batesste-ff]:https://github.com/sbates130272/batesste-firefly-iii
 [ref-speedtest]:https://github.com/billimek/prometheus-speedtest-exporter
+[ref-mountpoint]: https://github.com/awslabs/mountpoint-s3

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,41 @@
+# batesste-s3-dyndns
+
+A simple systemd and bash based method for backing whole disk images
+up to AWS S3 via [mountpoint-s3][ref-mountpoint].
+
+## Overview
+
+This simple framework runs a bash script once a day and uses dd to
+read a disk image, pipe it into a compression algorithm and then push
+the result to a AWS S3 bucket using the mountpoint-3 FUSE.
+
+## Installation
+
+Before performing these steps use the instructions at the
+[mountpoint][ref-mountpoint] site to ensure mountpoint is
+installed. You also need to ensure pigz is installed.
+
+Copy my AWS credentials into a file in this folder called
+```batesste-s3-backup.secrets``` and ensure it is of the form:
+```
+BLK_DEVICE=<the block device you want to backup>
+MOUNT_POINT=<the location for the mountpoint-s3 mount>
+AWS_ACCESS_KEY_ID=<my AWS key>
+AWS_SECRET_ACCESS_KEY=<my AWS secret>
+```
+Note that MOUNT_POINT must *not* exist and the script will fail if it
+does. the script will delete this folder once done. Also note that a
+FILE_MODE exists that can backup arbitrary files instead of block
+devices.
+
+Then proceed with the following steps:
+1. ```sudo cp batesste-s3-backup /usr/local/bin```.
+1. ```sudo cp batesste-s3-backup.service /etc/systemd/system/```.
+1. ```sudo cp batesste-s3-backup.timer /etc/systemd/system/```.
+1. ```sudo mkdir -p /usr/local/share/batesste-s3-backup```.
+1. ```sudo mv batesste-s3-backup.secrets /usr/local/share/batesste-s3-backup/```.
+1. ```sudo systemctl daemon-reload```
+1. ```sudo systemctl enable batesste-s3-backup.timer```
+1. ```sudo systemctl start batesste-s3-backup.timer```
+
+[ref-mountpoint]: https://github.com/awslabs/mountpoint-s3

--- a/backup/batesste-s3-backup
+++ b/backup/batesste-s3-backup
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# batesste-s3-backup
+# ------------------
+#
+# A simple script that will run as a systemd timer service on my home
+# server and backup any provided block devices to an AWS S3 object
+# using the mountpoint-s3 FUSE. There is also a FILE_MODE for backing
+# up arbitry files.
+
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-none}
+AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-none}
+AWS_REGION=${AWS_REGION:-us-west-2}
+AWS_BUCKET=${AWS_BUCKET:-batesste-homelab-backups}
+BLK_DEVICE=${BLK_DEVICE:-none}
+MOUNT_POINT=${MOUNT_POINT:-none}
+FILE_MODE=${FILE_MODE:-false}
+
+if [ $AWS_ACCESS_KEY_ID == "none" ]; then
+    echo "ERROR: You must specify an AWS_ACCESS_KEY_ID."
+    exit -1
+fi
+if [ $AWS_SECRET_ACCESS_KEY == "none" ]; then
+    echo "ERROR: You must specify an AWS_SECRET_ACCESS_KEY."
+    exit -1
+fi
+if [ $BLK_DEVICE == "none" ]; then
+    echo "ERROR: You must specify a block device."
+    exit -1
+fi
+if [ $FILE_MODE = "false" ] && [ ! -b $BLK_DEVICE ]; then
+    echo "ERROR: BLK_DEVICE (${BLK_DEVICE}) is not a block device."
+    exit -1
+fi
+if [ $MOUNT_POINT == "none" ]; then
+    echo "ERROR: You must specify a mount point."
+    exit -1
+fi
+if [ -e $MOUNT_POINT ]; then
+    echo "ERROR: MOUNT_POINT (${MOUNT_POINT}) already exists."
+    exit -1
+fi
+
+set -e
+
+function cleanup() {
+    umount ${MOUNT_POINT}
+    rm -rf ${MOUNT_POINT}
+}
+
+trap cleanup EXIT
+
+mkdir -p ${MOUNT_POINT}
+mount-s3 --region ${AWS_REGION} ${AWS_BUCKET} ${MOUNT_POINT}
+
+  # The backup name is the hostname-blk-device-datestamp.gz. Note that
+  # we replace backslashes in the block device name.
+
+FILENAME=$(uname -n)${BLK_DEVICE//"/"/"-"}-$(date +%F-%H-%M).gz
+
+echo "INFO: Performing backup to ${MOUNT_POINT}/${FILENAME}."
+
+dd if=${BLK_DEVICE} bs=1M |
+    pigz > ${MOUNT_POINT}/${FILENAME}

--- a/backup/batesste-s3-backup.service
+++ b/backup/batesste-s3-backup.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=My AWS S3-based backup system
+
+[Service]
+Type=simple
+Restart=no
+ExecStart=/usr/local/bin/batesste-s3-backup
+EnvironmentFile=/usr/local/share/batesste-s3-backup/batesste-s3-backup.secrets

--- a/backup/batesste-s3-backup.timer
+++ b/backup/batesste-s3-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=My AWS S3-based backup system
+
+[Timer]
+OnCalendar=01:*:*
+Persistent=true
+Unit=batesste-s3-backup.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
In order to do backups of the servers in my homelab we add a set of scripts that we can install as a systemd service. These scripts use dd, pigz and mount-s3 to copy a compressed version of a given set of block devices to an AWS S3 bucket.

We also add a GitHub CI test for this.