### PR TITLE
time-machine: Add a section on how to setup an Apple time machine

### DIFF
--- a/.github/workflows/batesste-homesetup-spellcheck.yml
+++ b/.github/workflows/batesste-homesetup-spellcheck.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
+      - name: Perform hack to get Linkspector to work on Ubuntu 24.04
+        run: |
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: GitHub spellcheck action
         uses: rojopolis/spellcheck-github-actions@0.45.0
       - name: Run Linkspector with reviewdog

--- a/.github/workflows/batesste-homesetup-time-machine-test.yml
+++ b/.github/workflows/batesste-homesetup-time-machine-test.yml
@@ -1,0 +1,26 @@
+name: batesste-homesetup
+on:
+  pull_request:
+    paths:
+      - 'time-machine/**'
+
+jobs:
+  time-machine-test:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ./time-machine
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Create .aws.creds.env file
+        run: |
+          echo "AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"" > .aws.creds.env
+          echo "AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}"" >> .aws.creds.env
+      - name: Create the external docker volume
+        run: docker volume create batesste-time-machine
+      - name: Docker Compose based smoke-test
+        uses: hoverkraft-tech/compose-action@v2.0.2
+        with:
+          compose-file: batesste-time-machine.dc.yml
+          cwd: ./time-machine

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 *.secrets
+.aws.creds.env

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -16,6 +16,7 @@ homesetup
 http
 IPv
 pigz
+MacBook
 md
 mountpoint
 README
@@ -24,5 +25,6 @@ Speedtest
 speedtest
 SSL
 systemd
+timemachine
 Tizen
 TXT

--- a/README.md
+++ b/README.md
@@ -69,6 +69,29 @@ We enable a full disk backup of servers to AWS S3 buckets using
 [mountpoint][ref-mountpoint] and a systemd service. See the
 [backup README.md](./backup/README.md) for more information.
 
+# Time Machine
+
+In order to backup my MacBook we use [this timemachine
+repo][ref-time-machine] on the home server. In order to get this
+started and in order to provide AWS S3 backup of the volume that
+contains the time machine data use the [docker
+compose](./time-machine/batesste-time-machine.yml) file.
+
+Place a ```.aws.creds.env``` file in the ```time-machine``` folder of
+the form:
+```bash
+AWS_ACCESS_KEY_ID="<my AWS id>"
+AWS_SECRET_ACCESS_KEY="<my AWS secret>
+```
+Then install using something like (only once ever):
+```bash
+cd time-machine
+docker volume create batesste-time-machine
+docker compose -f batesste-time-machine.dc.yml -d up
+```
+Note that since we are not broadcasting you will need to establish a
+link to the server via the instructions in main repo.
+
 [ref-aws-s3]: https://aws.amazon.com/s3/
 [ref-homebridge]: https://homebridge.io/
 [ref-ssl-certs]: https://www.kaspersky.com/resource-center/definitions/what-is-a-ssl-certificate
@@ -79,3 +102,4 @@ We enable a full disk backup of servers to AWS S3 buckets using
 [ref-batesste-ff]:https://github.com/sbates130272/batesste-firefly-iii
 [ref-speedtest]:https://github.com/billimek/prometheus-speedtest-exporter
 [ref-mountpoint]: https://github.com/awslabs/mountpoint-s3
+[ref-time-machine]: https://github.com/mbentley/docker-timemachine

--- a/time-machine/.backup.env
+++ b/time-machine/.backup.env
@@ -1,0 +1,25 @@
+# Configuration file for offen/docker-volume-backup
+# batesste-time-machine
+# January 2025
+#
+# See [1] for a full description of all the backup configurations
+# available.
+#
+# [1]: https://offen.github.io/docker-volume-backup/reference/
+
+# Run every day at 2330
+BACKUP_CRON_EXPRESSION="0 0 23 30 * ?"
+
+# Gzip compress backups using all available cpu threads
+BACKUP_COMPRESSION="gz"
+GZIP_PARALLELISM=0
+
+# The backup name
+BACKUP_FILENAME="batesste-time-machine-backup-%Y-%m-%dT%H-%M-%S.{{ .Extension }}"
+
+# AWS S3 Configuration
+AWS_S3_BUCKET_NAME="batesste-time-machine-backups"
+
+# Pruning of old backups
+BACKUP_RETENTION_DAYS="30"
+BACKUP_PRUNING_PREFIX="batesste-time-machine-backup-"

--- a/time-machine/.batesste-time-machine-env
+++ b/time-machine/.batesste-time-machine-env
@@ -1,0 +1,7 @@
+TM_USERNAME="timemachine"
+TM_GROUPNAME="timemachine"
+PASSWORD="timemachine"
+TM_UID="1000"
+TM_GID="1000"
+SET_PERMISSIONS="false"
+VOLUME_SIZE_LIMIT="0"

--- a/time-machine/batesste-time-machine.dc.yml
+++ b/time-machine/batesste-time-machine.dc.yml
@@ -1,0 +1,45 @@
+#
+# batesste-time-machine.dc.yml
+#
+
+services:
+
+  tm-app:
+    image: mbentley/timemachine:smb
+    hostname: batesste-time-machine
+    container_name: batesste-time-machine
+    networks:
+      - batesste-time-machine
+    restart: always
+    volumes:
+      - batesste-time-machine:/opt/timemachine
+    env_file: .batesste-time-machine-env
+    ports:
+      - "137:137/udp"
+      - "138:138/udp"
+      - "139:139"
+      - "445:445"
+
+  tm-backup:
+    image: offen/docker-volume-backup:latest
+    hostname: batesste-time-machine-backup
+    container_name: batesste-time-machine-backup
+    restart: always
+    env_file:
+      - .backup.env
+      - .aws.creds.env
+    volumes:
+      - batesste-time-machine:/backup/time-machine-backup:ro
+    depends_on:
+      - tm-app
+    networks:
+      - batesste-time-machine
+
+volumes:
+   batesste-time-machine:
+     external: true
+     name: batesste-time-machine
+
+networks:
+  batesste-time-machine:
+    driver: bridge


### PR DESCRIPTION
We can use a docker container to run a time machine compatabile service and use this to setup time-machine on Apple machines in our network. Also include a CI test.