### PR TITLE
systemd-timers: Fix some issues with my systemd timers

### DIFF
--- a/backup/batesste-s3-backup.timer
+++ b/backup/batesste-s3-backup.timer
@@ -2,8 +2,7 @@
 Description=My AWS S3-based backup system
 
 [Timer]
-OnCalendar=01:*:*
-Persistent=true
+OnCalendar=01:00:00
 Unit=batesste-s3-backup.service
 
 [Install]

--- a/dyndns/batesste-s3-dyndns.timer
+++ b/dyndns/batesste-s3-dyndns.timer
@@ -2,8 +2,8 @@
 Description=My AWS S3-based dynamic DNS resolver
 
 [Timer]
+OnBootSec=5min
 OnCalendar=*:0/15
-Persistent=true
 Unit=batesste-s3-dyndns.service
 
 [Install]


### PR DESCRIPTION
I had a couple of errors in my systemd timer files. In once case I had 01:*:* (which fires all through the hour) instead of 01:00:00 (which fires at the hour). I also had Persistent set to true and I do not need that. I also fix the dyndns timer so it always fires just after a reboot.