### PR TITLE
grafana: Add lemonade dashboards and AMD sysfs GPU exporter

### DIFF
--- a/amd-sysfs-gpu-exporter/amd-sysfs-gpu-exporter
+++ b/amd-sysfs-gpu-exporter/amd-sysfs-gpu-exporter
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Lightweight Prometheus exporter for AMD GPUs that reads
+metrics directly from sysfs/hwmon. Works around the
+amdsmi library limitation on Strix Halo (gfx1151) APUs
+where the official amd-gpu-metrics-exporter reports zeros
+for temperature, power, clocks, and utilization.
+
+See: https://github.com/ROCm/ROCm/issues/6035
+
+Usage:
+    ./amd-sysfs-gpu-exporter [--port PORT]
+
+Metrics are served at http://localhost:<PORT>/metrics in
+Prometheus text exposition format. No dependencies beyond
+Python 3 stdlib.
+"""
+
+import argparse
+import glob
+import os
+import re
+import socket
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+DEFAULT_PORT = 9402
+AMD_VENDOR = "0x1002"
+
+DEVICE_ID_TO_MODEL = {
+    "0x1586": "Radeon 8060S (Strix Halo)",
+    "0x1587": "Radeon 8050S (Strix Halo)",
+}
+
+
+def find_amd_gpus():
+    """Auto-discover AMD GPU cards via DRM subsystem."""
+    gpus = []
+    for card_dir in sorted(glob.glob("/sys/class/drm/card[0-9]*")):
+        dev_dir = os.path.join(card_dir, "device")
+        vendor_path = os.path.join(dev_dir, "vendor")
+        if not os.path.isfile(vendor_path):
+            continue
+        vendor = _read(vendor_path).strip()
+        if vendor != AMD_VENDOR:
+            continue
+
+        hwmon_dirs = glob.glob(
+            os.path.join(dev_dir, "hwmon", "hwmon*")
+        )
+        hwmon = hwmon_dirs[0] if hwmon_dirs else None
+
+        card_name = os.path.basename(card_dir)
+        gpus.append({
+            "card": card_name,
+            "dev": dev_dir,
+            "hwmon": hwmon,
+        })
+    return gpus
+
+
+def _read(path):
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except (OSError, IOError):
+        return ""
+
+
+def _read_int(path):
+    val = _read(path)
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def _read_float(path):
+    val = _read(path)
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_active_clock(pp_dpm_text):
+    """Parse pp_dpm_sclk/mclk for the active level."""
+    for line in pp_dpm_text.splitlines():
+        if "*" in line:
+            m = re.search(r"(\d+)\s*Mhz", line, re.I)
+            if m:
+                return int(m.group(1))
+    return None
+
+
+def collect_gpu_metrics(gpu, hostname):
+    """Collect all available metrics for one GPU."""
+    dev = gpu["dev"]
+    hwmon = gpu["hwmon"]
+    card = gpu["card"]
+    gpu_id = card.replace("card", "")
+    lines = []
+
+    device_id = _read(os.path.join(dev, "device"))
+    vbios = _read(os.path.join(dev, "vbios_version"))
+    card_model = DEVICE_ID_TO_MODEL.get(device_id, "")
+
+    base_labels = (
+        f'hostname="{hostname}",'
+        f'gpu_id="{gpu_id}",'
+        f'card="{card}",'
+        f'card_model="{card_model}"'
+    )
+
+    info_labels = (
+        f'{base_labels},'
+        f'device_id="{device_id}",'
+        f'vbios="{vbios}"'
+    )
+    lines.append(
+        "# HELP amd_sysfs_gpu_info "
+        "AMD GPU information from sysfs"
+    )
+    lines.append(
+        "# TYPE amd_sysfs_gpu_info gauge"
+    )
+    lines.append(
+        f"amd_sysfs_gpu_info{{{info_labels}}} 1"
+    )
+
+    if hwmon:
+        temp = _read_int(
+            os.path.join(hwmon, "temp1_input")
+        )
+        if temp is not None:
+            lines.append(
+                "# HELP amd_sysfs_gpu_temperature_celsius "
+                "GPU temperature in degrees Celsius"
+            )
+            lines.append(
+                "# TYPE amd_sysfs_gpu_temperature_celsius "
+                "gauge"
+            )
+            label = _read(
+                os.path.join(hwmon, "temp1_label")
+            ) or "edge"
+            lines.append(
+                f"amd_sysfs_gpu_temperature_celsius"
+                f'{{{base_labels},sensor="{label}"}}'
+                f" {temp / 1000.0}"
+            )
+
+        for pfx, desc in [
+            ("power1_average", "average"),
+            ("power1_input", "instant"),
+        ]:
+            val = _read_int(
+                os.path.join(hwmon, pfx)
+            )
+            if val is not None:
+                lines.append(
+                    "# HELP amd_sysfs_gpu_power_watts "
+                    "GPU power consumption in watts"
+                )
+                lines.append(
+                    "# TYPE amd_sysfs_gpu_power_watts "
+                    "gauge"
+                )
+                lines.append(
+                    f"amd_sysfs_gpu_power_watts"
+                    f'{{{base_labels},type="{desc}"}}'
+                    f" {val / 1e6}"
+                )
+
+        freq = _read_int(
+            os.path.join(hwmon, "freq1_input")
+        )
+        if freq is not None:
+            lines.append(
+                "# HELP amd_sysfs_gpu_clock_hz "
+                "GPU clock frequency in hertz"
+            )
+            lines.append(
+                "# TYPE amd_sysfs_gpu_clock_hz gauge"
+            )
+            label = _read(
+                os.path.join(hwmon, "freq1_label")
+            ) or "sclk"
+            lines.append(
+                f"amd_sysfs_gpu_clock_hz"
+                f'{{{base_labels},clock="{label}"}}'
+                f" {freq}"
+            )
+
+        for idx, name in [("0", "vddgfx"), ("1", "vddnb")]:
+            val = _read_int(
+                os.path.join(hwmon, f"in{idx}_input")
+            )
+            label = _read(
+                os.path.join(hwmon, f"in{idx}_label")
+            ) or name
+            if val is not None:
+                lines.append(
+                    "# HELP amd_sysfs_gpu_voltage_mv "
+                    "GPU voltage in millivolts"
+                )
+                lines.append(
+                    "# TYPE amd_sysfs_gpu_voltage_mv "
+                    "gauge"
+                )
+                lines.append(
+                    f"amd_sysfs_gpu_voltage_mv"
+                    f'{{{base_labels},rail="{label}"}}'
+                    f" {val}"
+                )
+
+    busy = _read_int(
+        os.path.join(dev, "gpu_busy_percent")
+    )
+    if busy is not None:
+        lines.append(
+            "# HELP amd_sysfs_gpu_busy_percent "
+            "GPU utilization percentage"
+        )
+        lines.append(
+            "# TYPE amd_sysfs_gpu_busy_percent gauge"
+        )
+        lines.append(
+            f"amd_sysfs_gpu_busy_percent"
+            f"{{{base_labels}}} {busy}"
+        )
+
+    pp_sclk = _read(os.path.join(dev, "pp_dpm_sclk"))
+    if pp_sclk:
+        mhz = _parse_active_clock(pp_sclk)
+        if mhz is not None:
+            lines.append(
+                "# HELP amd_sysfs_gpu_sclk_mhz "
+                "Active shader clock in MHz"
+            )
+            lines.append(
+                "# TYPE amd_sysfs_gpu_sclk_mhz gauge"
+            )
+            lines.append(
+                f"amd_sysfs_gpu_sclk_mhz"
+                f"{{{base_labels}}} {mhz}"
+            )
+
+    pp_mclk = _read(os.path.join(dev, "pp_dpm_mclk"))
+    if pp_mclk:
+        mhz = _parse_active_clock(pp_mclk)
+        if mhz is not None:
+            lines.append(
+                "# HELP amd_sysfs_gpu_mclk_mhz "
+                "Active memory clock in MHz"
+            )
+            lines.append(
+                "# TYPE amd_sysfs_gpu_mclk_mhz gauge"
+            )
+            lines.append(
+                f"amd_sysfs_gpu_mclk_mhz"
+                f"{{{base_labels}}} {mhz}"
+            )
+
+    for mem_type in [
+        "vram_total", "vram_used",
+        "gtt_total", "gtt_used",
+        "vis_vram_total", "vis_vram_used",
+    ]:
+        val = _read_int(
+            os.path.join(dev, f"mem_info_{mem_type}")
+        )
+        if val is not None:
+            lines.append(
+                "# HELP amd_sysfs_gpu_memory_bytes "
+                "GPU memory in bytes"
+            )
+            lines.append(
+                "# TYPE amd_sysfs_gpu_memory_bytes gauge"
+            )
+            lines.append(
+                f"amd_sysfs_gpu_memory_bytes"
+                f'{{{base_labels},type="{mem_type}"}}'
+                f" {val}"
+            )
+
+    link_speed = _read(
+        os.path.join(dev, "current_link_speed")
+    )
+    if link_speed:
+        m = re.match(r"([\d.]+)", link_speed)
+        if m:
+            lines.append(
+                "# HELP amd_sysfs_gpu_pcie_speed_gts "
+                "PCIe link speed in GT/s"
+            )
+            lines.append(
+                "# TYPE amd_sysfs_gpu_pcie_speed_gts "
+                "gauge"
+            )
+            lines.append(
+                f"amd_sysfs_gpu_pcie_speed_gts"
+                f"{{{base_labels}}} {m.group(1)}"
+            )
+
+    link_width = _read_int(
+        os.path.join(dev, "current_link_width")
+    )
+    if link_width is not None:
+        lines.append(
+            "# HELP amd_sysfs_gpu_pcie_width "
+            "PCIe link width (lanes)"
+        )
+        lines.append(
+            "# TYPE amd_sysfs_gpu_pcie_width gauge"
+        )
+        lines.append(
+            f"amd_sysfs_gpu_pcie_width"
+            f"{{{base_labels}}} {link_width}"
+        )
+
+    return lines
+
+
+def collect_all():
+    hostname = socket.gethostname()
+    gpus = find_amd_gpus()
+    lines = []
+    for gpu in gpus:
+        lines.extend(collect_gpu_metrics(gpu, hostname))
+    return "\n".join(lines) + "\n"
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/metrics":
+            body = collect_all().encode("utf-8")
+            self.send_response(200)
+            self.send_header(
+                "Content-Type",
+                "text/plain; version=0.0.4; charset=utf-8"
+            )
+            self.send_header(
+                "Content-Length", str(len(body))
+            )
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/":
+            body = (
+                "<html><body>"
+                "<a href='/metrics'>Metrics</a>"
+                "</body></html>"
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, fmt, *args):
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="AMD GPU sysfs Prometheus exporter"
+    )
+    parser.add_argument(
+        "--port", type=int, default=DEFAULT_PORT,
+        help=f"Port to listen on (default: {DEFAULT_PORT})"
+    )
+    args = parser.parse_args()
+
+    gpus = find_amd_gpus()
+    if not gpus:
+        print("No AMD GPUs found in /sys/class/drm/")
+        raise SystemExit(1)
+
+    for gpu in gpus:
+        print(f"Found AMD GPU: {gpu['card']} "
+              f"(hwmon: {gpu['hwmon']})")
+
+    server = HTTPServer(("", args.port), MetricsHandler)
+    print(f"Serving metrics on :{args.port}/metrics")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/amd-sysfs-gpu-exporter/amd-sysfs-gpu-exporter.service
+++ b/amd-sysfs-gpu-exporter/amd-sysfs-gpu-exporter.service
@@ -1,0 +1,16 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=AMD GPU sysfs Prometheus exporter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/amd-sysfs-gpu-exporter
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/grafana/dashboards/amd-related/cpu-gpu-monitoring.json
+++ b/grafana/dashboards/amd-related/cpu-gpu-monitoring.json
@@ -1,0 +1,3072 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "displayMode": "color-text",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "card_model"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": ""
+              },
+              {
+                "id": "custom.width",
+                "value": 300
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^(?!card_model$).*$/"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": false,
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_info{hostname=\"$host\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A",
+          "legendFormat": "{{card_model}}"
+        }
+      ],
+      "title": "GPU Model",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "card_vendor": true,
+              "cluster_name": true,
+              "driver_version": true,
+              "gpu_compute_partition_type": true,
+              "gpu_id": true,
+              "gpu_memory_partition_type": true,
+              "gpu_partition_id": true,
+              "gpu_uuid": true,
+              "hostname": true,
+              "instance": true,
+              "job": true,
+              "vbios_version": true
+            },
+            "indexByName": {
+              "card_model": 0
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 101,
+      "options": {
+        "content": "## ROCm 7.2.0",
+        "mode": "markdown"
+      },
+      "title": "ROCm Version",
+      "type": "text"
+    },
+    {
+      "description": "Current GPU graphics activity percentage.\n\nShows how much of the GPU's compute units are actively processing workloads. Values near 100% indicate the GPU is fully utilized.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_busy_percent{hostname=\"$host\"}",
+          "legendFormat": "GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Utilization",
+      "type": "stat"
+    },
+    {
+      "description": "Whether the Lemonade server is up and responding (1 = up, 0 = down).\n\nThis metric is based on successful health checks. If this shows 0, the server may be down, unreachable, or timing out.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "text": "DOWN"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "color": "green",
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 109,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_server_up{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Server Status",
+      "type": "stat"
+    },
+    {
+      "description": "Percentage of GPU VRAM currently in use.\n\nHigh values (>90%) may indicate memory pressure. Monitor this to ensure models and data fit within available VRAM.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "(amd_sysfs_gpu_memory_bytes{hostname=\"$host\",type=\"vram_used\"} / amd_sysfs_gpu_memory_bytes{hostname=\"$host\",type=\"vram_total\"}) * 100",
+          "refId": "A",
+          "legendFormat": "VRAM %"
+        }
+      ],
+      "title": "VRAM Usage",
+      "type": "stat"
+    },
+    {
+      "description": "Current token generation rate from the last request.\n\nShows how fast the server is generating tokens. Higher values indicate better performance. This is a per-request value, not an average.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "orange",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 4
+      },
+      "id": 110,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_tokens_per_second{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Tokens Per Second",
+      "type": "stat"
+    },
+    {
+      "description": "Current GPU edge temperature.\n\nNormal operating temperatures are typically 40-80\u00b0C. Temperatures above 90\u00b0C may indicate cooling issues or excessive load.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_temperature_celsius{hostname=\"$host\"}",
+          "legendFormat": "Temp",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Temperature",
+      "type": "stat"
+    },
+    {
+      "description": "Time taken to generate the first token from the last request.\n\nLower values indicate faster response times. Includes prompt processing time. Typical values range from 0.1-2 seconds depending on model size and hardware.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 3,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 4
+      },
+      "id": 111,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_time_to_first_token_seconds{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Time to First Token",
+      "type": "stat"
+    },
+    {
+      "description": "GPU Power and Server Power (W) over time.\nTotal Energy values (J) are in the legend table.\n\nEnergy = avg_over_time(power) \u00d7 time_range",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineWidth": 2,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "watt"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "GPU Total Energy"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "joule"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Server Total Energy"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "joule"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_power_watts{type=\"average\", hostname=\"$host\"}",
+          "legendFormat": "GPU Power",
+          "refId": "A"
+        },
+        {
+          "expr": "snoc_pinewood_plug_d_power",
+          "legendFormat": "Server Power",
+          "refId": "B"
+        },
+        {
+          "expr": "snoc_pinewood_plug_h_power",
+          "legendFormat": "Server Power",
+          "refId": "L"
+        },
+        {
+          "expr": "avg_over_time(amd_sysfs_gpu_power_watts{type=\"average\", hostname=\"$host\"}[$__range]) * ($__range_ms / 1000)",
+          "hide": true,
+          "legendFormat": "GPU Total Energy",
+          "refId": "C"
+        },
+        {
+          "expr": "avg_over_time(snoc_pinewood_plug_d_power[$__range]) * ($__range_ms / 1000)",
+          "hide": true,
+          "legendFormat": "Server Total Energy",
+          "refId": "D"
+        },
+        {
+          "expr": "avg_over_time(snoc_pinewood_plug_h_power[$__range]) * ($__range_ms / 1000)",
+          "hide": true,
+          "legendFormat": "Server Total Energy",
+          "refId": "N"
+        }
+      ],
+      "title": "Power & Energy",
+      "type": "timeseries"
+    },
+    {
+      "description": "Number of models currently loaded in memory.\n\nShows how many models are available for inference. Monitor to ensure models are loaded correctly and track memory usage.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 4
+      },
+      "id": 112,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_models_loaded{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Models Loaded",
+      "type": "stat"
+    },
+    {
+      "description": "GPU graphics activity percentage over time.\n\nTrack GPU workload patterns and identify periods of high or low utilization. Useful for capacity planning and performance optimization.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_busy_percent{hostname=\"$host\"}",
+          "legendFormat": "GPU {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Utilization Over Time",
+      "type": "timeseries"
+    },
+    {
+      "description": "GPU VRAM usage percentage and absolute values over time.\n\nUsed: Currently allocated VRAM in GB.\nTotal: Total available VRAM in GB.\n\nMonitor trends to detect memory leaks or plan for model loading strategies.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used (GB)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decgbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total (GB)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decgbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "gray",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "(amd_sysfs_gpu_memory_bytes{hostname=\"$host\",type=\"vram_used\"} / amd_sysfs_gpu_memory_bytes{hostname=\"$host\",type=\"vram_total\"}) * 100",
+          "legendFormat": "VRAM %",
+          "refId": "A"
+        },
+        {
+          "expr": "amd_sysfs_gpu_memory_bytes{hostname=\"$host\",type=\"vram_used\"}",
+          "legendFormat": "Used (GB)",
+          "refId": "B"
+        },
+        {
+          "expr": "amd_sysfs_gpu_memory_bytes{hostname=\"$host\",type=\"vram_total\"}",
+          "legendFormat": "Total (GB)",
+          "refId": "C"
+        }
+      ],
+      "title": "VRAM Usage Over Time",
+      "type": "timeseries"
+    },
+    {
+      "description": "GPU temperature and power consumption over time.\n\nTemp: Edge temperature (\u00b0C).\nJunction Temp: Hotspot temperature (\u00b0C) - typically higher than edge temp.\nPower: Average package power consumption (W).\n\nCorrelate temperature with power to identify thermal throttling or cooling issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Power (W)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "watt"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.scaleDistribution",
+                "value": {
+                  "min": 0,
+                  "type": "linear"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_temperature_celsius{hostname=\"$host\"}",
+          "legendFormat": "Temp",
+          "refId": "A"
+        },
+        {
+          "expr": "amd_sysfs_gpu_temperature_celsius{hostname=\"$host\",sensor=\"edge\"}",
+          "legendFormat": "Edge (only sensor)",
+          "refId": "B"
+        },
+        {
+          "expr": "amd_sysfs_gpu_power_watts{type=\"average\", hostname=\"$host\"}",
+          "legendFormat": "Power (W)",
+          "refId": "C"
+        }
+      ],
+      "title": "GPU Temperature & Power",
+      "type": "timeseries"
+    },
+    {
+      "description": "Token counts from the most recent request over time.\n\nInput: Tokens in the user's prompt.\nOutput: Tokens generated by the model.\nPrompt: Total prompt tokens (may include cached tokens).\n\nUseful for understanding request patterns and token usage.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "lemonade_input_tokens_last{node=\"$host\"}",
+          "legendFormat": "Input",
+          "refId": "A"
+        },
+        {
+          "expr": "lemonade_output_tokens_last{node=\"$host\"}",
+          "legendFormat": "Output",
+          "refId": "B"
+        },
+        {
+          "expr": "lemonade_prompt_tokens_last{node=\"$host\"}",
+          "legendFormat": "Prompt",
+          "refId": "C"
+        }
+      ],
+      "title": "Lemonade Last Request Tokens",
+      "type": "timeseries"
+    },
+    {
+      "description": "Key performance metrics over time.\n\nTokens/sec: Generation rate from last request.\nTime to First Token: Latency to first token.\nOutput Rate: Average output token rate over 5 minutes.\n\nMonitor these to track server performance and identify bottlenecks.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time to First Token (s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Output Rate (tokens/s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 8,
+        "y": 9
+      },
+      "id": 114,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "lemonade_tokens_per_second{node=\"$host\"}",
+          "legendFormat": "Tokens/sec",
+          "refId": "A"
+        },
+        {
+          "expr": "lemonade_time_to_first_token_seconds{node=\"$host\"}",
+          "legendFormat": "Time to First Token (s)",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(lemonade_output_tokens_total{node=\"$host\"}[5m])",
+          "legendFormat": "Output Rate (tokens/s)",
+          "refId": "C"
+        }
+      ],
+      "title": "Lemonade Performance Metrics",
+      "type": "timeseries"
+    },
+    {
+      "description": "1-minute average CPU load.\n\nLoad represents the average number of processes waiting for CPU time. Values above the number of CPU cores indicate system overload.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "orange",
+                "value": 4
+              },
+              {
+                "color": "red",
+                "value": 8
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "node_load1{instance=\"$node_instance\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Load (1min)",
+      "type": "stat"
+    },
+    {
+      "description": "Percentage of system RAM currently in use.\n\nHigh memory usage (>90%) may cause swapping and performance degradation. Monitor to ensure adequate RAM for workloads.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "(1 - (node_memory_MemAvailable_bytes{instance=\"$node_instance\"} / node_memory_MemTotal_bytes{instance=\"$node_instance\"})) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Memory Usage",
+      "type": "stat"
+    },
+    {
+      "description": "Current disk read rate.\n\nShows data being read from storage devices. High read rates may indicate data loading, model loading, or cache misses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Total /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Rate /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 14
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "irate(node_disk_read_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"}[5m])",
+          "legendFormat": "Rate {{device}}",
+          "refId": "A"
+        },
+        {
+          "expr": "node_disk_read_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"} - (node_disk_read_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"} @ start())",
+          "hide": false,
+          "legendFormat": "Total {{device}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk Reads",
+      "type": "stat"
+    },
+    {
+      "description": "Current disk write rate.\n\nShows data being written to storage devices. High write rates may indicate logging, checkpointing, or data persistence operations.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Total /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Rate /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "irate(node_disk_written_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"}[5m])",
+          "legendFormat": "Rate {{device}}",
+          "refId": "A"
+        },
+        {
+          "expr": "node_disk_written_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"} - (node_disk_written_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"} @ start())",
+          "hide": false,
+          "legendFormat": "Total {{device}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk Writes",
+      "type": "stat"
+    },
+    {
+      "description": "Estimated number of concurrent users based on request patterns.\n\nCalculated from requests within a sliding window. Useful for understanding server load and capacity planning.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "id": 116,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_concurrent_users{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Concurrent Users",
+      "type": "stat"
+    },
+    {
+      "description": "Total cumulative number of sessions processed.\n\nEach new request increments this counter. Useful for tracking overall server usage and workload volume over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "id": 117,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_total_sessions_total{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Total Sessions",
+      "type": "stat"
+    },
+    {
+      "description": "Estimated number of requests currently being processed.\n\nBased on request timestamps and estimated durations. High values indicate the server is handling multiple concurrent requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "id": 118,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_active_requests{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Active Requests",
+      "type": "stat"
+    },
+    {
+      "description": "CPU load averages (1min, 5min, 15min) and memory usage percentage over time.\n\nLoad averages show system demand trends. Memory % shows RAM utilization. Monitor for capacity planning and performance issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "node_load1{instance=\"$node_instance\"}",
+          "legendFormat": "Load 1min",
+          "refId": "A"
+        },
+        {
+          "expr": "node_load5{instance=\"$node_instance\"}",
+          "legendFormat": "Load 5min",
+          "refId": "B"
+        },
+        {
+          "expr": "node_load15{instance=\"$node_instance\"}",
+          "legendFormat": "Load 15min",
+          "refId": "C"
+        },
+        {
+          "expr": "(1 - (node_memory_MemAvailable_bytes{instance=\"$node_instance\"} / node_memory_MemTotal_bytes{instance=\"$node_instance\"})) * 100",
+          "legendFormat": "Memory %",
+          "refId": "D"
+        }
+      ],
+      "title": "CPU Load & Memory",
+      "type": "timeseries"
+    },
+    {
+      "description": "Disk read and write rates over time.\n\nRead Rate: Data read from storage (MB/s).\nWrite Rate: Data written to storage (MB/s).\n\nHigh I/O rates may indicate heavy data processing, model loading, or logging activity.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "irate(node_disk_read_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"}[5m])",
+          "legendFormat": "Read {{device}}",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(node_disk_written_bytes_total{instance=\"$node_instance\", device=~\"nvme.*\"}[5m])",
+          "legendFormat": "Write {{device}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Disk I/O",
+      "type": "timeseries"
+    },
+    {
+      "description": "Prompt Throughput: Average tokens per second processed during prompt phase.\nGeneration Throughput: Average tokens per second generated during inference.\n\nHigher values indicate better performance. Prompt throughput is typically much higher than generation throughput.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 119,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "lemonade_llamacpp_prompt_tokens_per_second{node=\"$host\"}",
+          "legendFormat": "{{model_name}} - Prompt",
+          "refId": "A"
+        },
+        {
+          "expr": "lemonade_llamacpp_predicted_tokens_per_second{node=\"$host\"}",
+          "legendFormat": "{{model_name}} - Generation",
+          "refId": "B"
+        }
+      ],
+      "title": "Lemonade llama.cpp Backend Throughput",
+      "type": "timeseries"
+    },
+    {
+      "description": "Processing: Number of requests currently being processed by the backend.\nDeferred: Number of requests waiting in queue (deferred due to capacity limits).\n\nHigh deferred counts indicate the backend is at capacity. Monitor this to detect when additional backends or resources are needed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 120,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "lemonade_llamacpp_requests_processing{node=\"$host\"}",
+          "legendFormat": "{{model_name}} Processing",
+          "refId": "A"
+        },
+        {
+          "expr": "lemonade_llamacpp_requests_deferred{node=\"$host\"}",
+          "legendFormat": "{{model_name}} Deferred",
+          "refId": "B"
+        }
+      ],
+      "title": "Lemonade llama.cpp Backend Requests",
+      "type": "timeseries"
+    },
+    {
+      "description": "Generation load factor: ratio of generation time to wall clock time.\n\nValues range from 0.0 to 1.0+:\n- 0.0-0.5: Low load (generation time < 50% of wall clock)\n- 0.5-1.0: Moderate to high load\n- 1.0+: Very high load (multiple concurrent requests)\n\nCalculated as: increase(generation_time_total[5m]) / 300 - shows generation seconds per wall clock second over 5-minute window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 121,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(lemonade_llamacpp_tokens_predicted_seconds_total{node=\"$host\"}[5m]) / 300",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade llama.cpp Generation Load Factor",
+      "type": "timeseries"
+    },
+    {
+      "description": "Unified Memory Controller (UMC) activity percentage.\n\nUMC manages GPU memory subsystem. High activity indicates active memory operations. Monitor for memory bandwidth bottlenecks.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 31
+      },
+      "id": 102,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_busy_percent{hostname=\"$host\"}",
+          "legendFormat": "UMC {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "UMC Activity",
+      "type": "stat"
+    },
+    {
+      "description": "Video Core Next (VCN) activity percentage.\n\nVCN handles video encoding/decoding. Activity indicates video processing workloads. Typically low for AI inference workloads.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 31
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "amd_gpu_vcn_activity{hostname=\"$host\"}",
+          "legendFormat": "VCN {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "VCN Activity",
+      "type": "stat"
+    },
+    {
+      "description": "Matrix Multiply Accelerator (MMA) activity percentage.\n\nMMA handles matrix operations used in AI/ML workloads. High activity indicates active inference or training operations.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 31
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "amd_gpu_mma_activity{hostname=\"$host\"}",
+          "legendFormat": "MMA {{gpu_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MMA Activity",
+      "type": "stat"
+    },
+    {
+      "description": "Various GPU activity metrics over time.\n\nGFX: Graphics/compute activity.\nUMC: Memory controller activity.\nVCN: Video codec activity.\nMMA: Matrix multiply accelerator activity.\n\nCompare different activity types to understand GPU workload composition.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 105,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_busy_percent{hostname=\"$host\"}",
+          "legendFormat": "GFX Activity",
+          "refId": "A"
+        },
+        {
+          "expr": "amd_sysfs_gpu_busy_percent{hostname=\"$host\"}",
+          "legendFormat": "UMC Activity",
+          "refId": "B"
+        },
+        {
+          "expr": "amd_gpu_vcn_activity{hostname=\"$host\"}",
+          "legendFormat": "VCN Activity",
+          "refId": "C"
+        },
+        {
+          "expr": "amd_gpu_mma_activity{hostname=\"$host\"}",
+          "legendFormat": "MMA Activity",
+          "refId": "D"
+        }
+      ],
+      "title": "GPU Activity Metrics Over Time",
+      "type": "timeseries"
+    },
+    {
+      "description": "VRAM bandwidth utilization and cumulative data transfer over time.\n\nRead/Write Bandwidth: Current memory bandwidth usage (GB/s).\nTotal Read/Write/Transfer: Cumulative data moved over the time range (GB).\n\nHigh bandwidth indicates active GPU memory operations. Cumulative totals show overall data movement.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "decgbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/Total (Read|Write|Transfer)/"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "gray",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "unit",
+                "value": "decgbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "amd_gpu_memory_bandwidth_read_bytes_per_second{hostname=\"$host\"} / 1024 / 1024 / 1024",
+          "legendFormat": "Read Rate (GB/s)",
+          "refId": "A"
+        },
+        {
+          "expr": "amd_gpu_memory_bandwidth_write_bytes_per_second{hostname=\"$host\"} / 1024 / 1024 / 1024",
+          "legendFormat": "Write Rate (GB/s)",
+          "refId": "B"
+        },
+        {
+          "expr": "(amd_gpu_memory_bandwidth_read_bytes_per_second{hostname=\"$host\"} + amd_gpu_memory_bandwidth_write_bytes_per_second{hostname=\"$host\"}) / 1024 / 1024 / 1024",
+          "legendFormat": "Total Rate (GB/s)",
+          "refId": "C"
+        },
+        {
+          "expr": "avg_over_time(amd_gpu_memory_bandwidth_read_bytes_per_second{hostname=\"$host\"}[$__range]) * ($__range_ms / 1000) / 1024 / 1024 / 1024",
+          "hide": false,
+          "legendFormat": "Total Read (GB)",
+          "refId": "D"
+        },
+        {
+          "expr": "avg_over_time(amd_gpu_memory_bandwidth_write_bytes_per_second{hostname=\"$host\"}[$__range]) * ($__range_ms / 1000) / 1024 / 1024 / 1024",
+          "hide": false,
+          "legendFormat": "Total Write (GB)",
+          "refId": "E"
+        },
+        {
+          "expr": "avg_over_time((amd_gpu_memory_bandwidth_read_bytes_per_second{hostname=\"$host\"} + amd_gpu_memory_bandwidth_write_bytes_per_second{hostname=\"$host\"})[$__range]) * ($__range_ms / 1000) / 1024 / 1024 / 1024",
+          "hide": false,
+          "legendFormat": "Total Transfer (GB)",
+          "refId": "F"
+        }
+      ],
+      "title": "VRAM Bandwidth & Data Transfer",
+      "type": "timeseries"
+    },
+    {
+      "description": "Network receive rate over time.\n\nShows incoming network traffic. High rates may indicate API requests, model downloads, or data ingestion.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Total /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Rate /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 57
+      },
+      "id": 106,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "irate(node_network_receive_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"}[5m])",
+          "legendFormat": "Rate {{device}}",
+          "refId": "A"
+        },
+        {
+          "expr": "node_network_receive_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"} - (node_network_receive_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"} @ start())",
+          "hide": false,
+          "legendFormat": "Total {{device}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Network Receive",
+      "type": "stat"
+    },
+    {
+      "description": "Network transmit rate over time.\n\nShows outgoing network traffic. High rates may indicate API responses, data exports, or streaming outputs.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Total /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "decbytes"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^Rate /"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "Bps"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 57
+      },
+      "id": 107,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "irate(node_network_transmit_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"}[5m])",
+          "legendFormat": "Rate {{device}}",
+          "refId": "A"
+        },
+        {
+          "expr": "node_network_transmit_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"} - (node_network_transmit_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"} @ start())",
+          "hide": false,
+          "legendFormat": "Total {{device}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Network Transmit",
+      "type": "stat"
+    },
+    {
+      "description": "Network receive and transmit rates over time.\n\nReceive Rate: Incoming traffic (MB/s).\nTransmit Rate: Outgoing traffic (MB/s).\n\nMonitor network activity to understand API usage patterns and bandwidth requirements.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "irate(node_network_receive_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"}[5m])",
+          "legendFormat": "RX {{device}}",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(node_network_transmit_bytes_total{instance=\"$node_instance\", device!~\"lo|docker.*|veth.*|virbr.*\"}[5m])",
+          "legendFormat": "TX {{device}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Network I/O",
+      "type": "timeseries"
+    },
+    {
+      "description": "Distribution of token decode times.\n\nShows how long it takes to decode each token. Heatmap visualization with time buckets on Y-axis and time ranges on X-axis. Lower decode times indicate better performance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "spectrum"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent"
+              },
+              {
+                "color": "dark-blue",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 115,
+      "options": {
+        "calculate": false,
+        "cellGap": 2,
+        "cellValues": {
+          "unit": "short"
+        },
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "spectrum",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(lemonade_decode_token_time_seconds_bucket{node=\"$host\"}[5m])) by (le)",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Token Decode Time Histogram",
+      "type": "heatmap"
+    },
+    {
+      "description": "KV cache hit rate from the last request (0.0-1.0).\n\nShows what fraction of prompt tokens were served from cache vs processed fresh. Higher values indicate better cache effectiveness, leading to faster responses and lower compute costs.\n\n- >0.8: Excellent cache performance\n- 0.5-0.8: Good cache performance\n- <0.5: Poor cache performance - investigate cache configuration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red"
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 72
+      },
+      "id": 122,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "lemonade_cache_hit_rate{node=\"$host\"}",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Cache Hit Rate",
+      "type": "stat"
+    },
+    {
+      "description": "Rate of llama_decode() calls per second for each backend model.\n\nShows backend activity level and generation frequency. Higher rates indicate more active token generation. Useful for comparing model utilization and identifying which models are handling the most requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 72
+      },
+      "id": 123,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(lemonade_llamacpp_n_decode_total{node=\"$host\"}[5m])",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lemonade Backend Decode Call Rate",
+      "type": "timeseries"
+    },
+    {
+      "description": "Overall token processing rates across all requests.\n\nInput Rate: Average input tokens per second (prompt processing).\nOutput Rate: Average output tokens per second (generation).\n\nShows aggregate system throughput over time. Useful for capacity planning, workload analysis, and tracking overall system performance trends.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "tokens/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 72
+      },
+      "id": 124,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(lemonade_input_tokens_total{node=\"$host\"}[5m])",
+          "legendFormat": "Input Rate",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(lemonade_output_tokens_total{node=\"$host\"}[5m])",
+          "legendFormat": "Output Rate",
+          "refId": "B"
+        }
+      ],
+      "title": "Lemonade Token Processing Rates",
+      "type": "timeseries"
+    },
+    {
+      "description": "Rate of GPU kernel dispatches per second.\n\nShows the frequency of GPU kernel launches (decode operations) over time. Higher rates indicate more active GPU computation. This metric tracks the llama_decode() kernel dispatches, providing insight into GPU workload intensity and generation activity.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 125,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "rate(lemonade_llamacpp_n_decode_total{node=\"$host\"}[5m])",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GPU Kernel Dispatch Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 42,
+  "tags": [
+    "cpu",
+    "gpu",
+    "amd",
+    "rocm"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Host",
+        "multi": false,
+        "name": "host",
+        "options": [],
+        "query": {
+          "query": "label_values(lemonade_server_up, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "node_instance",
+        "options": [],
+        "query": {
+          "query": "label_values(node_uname_info{nodename=\"$host\"}, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "GPU ID",
+        "name": "gpu_id",
+        "options": [],
+        "query": {
+          "query": "label_values(amd_sysfs_gpu_info{hostname=\"$host\"}, gpu_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Lemonade: CPU & GPU Monitoring Dashboard",
+  "weekStart": "",
+  "uid": "cpu-gpu-monitoring"
+}

--- a/grafana/dashboards/general/lemonade-server-dashboard.json
+++ b/grafana/dashboards/general/lemonade-server-dashboard.json
@@ -106,79 +106,6 @@
       }
     },
     {
-      "id": 3,
-      "title": "GPU Health",
-      "type": "stat",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "ae8pyuqoyonpca"
-      },
-      "targets": [
-        {
-          "expr": "gpu_health{hostname=\"$node\"}",
-          "refId": "A",
-          "legendFormat": ""
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "UNHEALTHY",
-                  "color": "red",
-                  "index": 0
-                },
-                "1": {
-                  "text": "HEALTHY",
-                  "color": "green",
-                  "index": 1
-                }
-              }
-            }
-          ]
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "orientation": "auto",
-        "textMode": "value",
-        "colorMode": "background",
-        "graphMode": "none"
-      },
-      "gridPos": {
-        "x": 4,
-        "y": 1,
-        "w": 4,
-        "h": 4
-      }
-    },
-    {
       "id": 4,
       "title": "Models Loaded",
       "type": "stat",
@@ -225,7 +152,7 @@
         "graphMode": "none"
       },
       "gridPos": {
-        "x": 8,
+        "x": 4,
         "y": 1,
         "w": 4,
         "h": 4
@@ -278,7 +205,7 @@
         "graphMode": "none"
       },
       "gridPos": {
-        "x": 12,
+        "x": 8,
         "y": 1,
         "w": 4,
         "h": 4
@@ -331,7 +258,7 @@
         "graphMode": "none"
       },
       "gridPos": {
-        "x": 16,
+        "x": 12,
         "y": 1,
         "w": 4,
         "h": 4
@@ -393,7 +320,7 @@
         "graphMode": "none"
       },
       "gridPos": {
-        "x": 20,
+        "x": 16,
         "y": 1,
         "w": 4,
         "h": 4
@@ -1018,8 +945,294 @@
       }
     },
     {
+      "id": 32,
+      "title": "GPU Model",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "ae8pyuqoyonpca"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_info{hostname=\"$node\"}",
+          "refId": "A",
+          "legendFormat": "{{card_model}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "name",
+        "colorMode": "background_solid",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 8,
+        "h": 3
+      }
+    },
+    {
+      "id": 33,
+      "title": "GPU ID",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "ae8pyuqoyonpca"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_info{hostname=\"$node\"}",
+          "refId": "A",
+          "legendFormat": "gpu_id={{gpu_id}} ({{device_id}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "name",
+        "colorMode": "background_solid",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 24,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "id": 34,
+      "title": "GPU Count",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "ae8pyuqoyonpca"
+      },
+      "targets": [
+        {
+          "expr": "count(amd_sysfs_gpu_info{hostname=\"$node\"})",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 24,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "id": 35,
+      "title": "Total VRAM",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "ae8pyuqoyonpca"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_memory_bytes{hostname=\"$node\",type=\"vram_total\"}",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 24,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
+      "id": 36,
+      "title": "GPU Health",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "ae8pyuqoyonpca"
+      },
+      "targets": [
+        {
+          "expr": "amd_sysfs_gpu_info{hostname=\"$node\"}",
+          "refId": "A",
+          "legendFormat": ""
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 0
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "value",
+        "colorMode": "background",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 20,
+        "y": 24,
+        "w": 4,
+        "h": 3
+      }
+    },
+    {
       "id": 21,
-      "title": "VRAM Usage (MB)",
+      "title": "VRAM Usage",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
@@ -1027,19 +1240,14 @@
       },
       "targets": [
         {
-          "expr": "gpu_used_vram{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_memory_bytes{hostname=\"$node\",type=\"vram_used\"}",
           "refId": "A",
           "legendFormat": "Used"
         },
         {
-          "expr": "gpu_total_vram{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_memory_bytes{hostname=\"$node\",type=\"vram_total\"}",
           "refId": "B",
           "legendFormat": "Total"
-        },
-        {
-          "expr": "gpu_free_vram{hostname=\"$node\"}",
-          "refId": "C",
-          "legendFormat": "Free"
         }
       ],
       "fieldConfig": {
@@ -1065,7 +1273,7 @@
               }
             ]
           },
-          "unit": "decmbytes"
+          "unit": "bytes"
         },
         "overrides": []
       },
@@ -1082,7 +1290,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 24,
+        "y": 27,
         "w": 8,
         "h": 8
       }
@@ -1097,14 +1305,9 @@
       },
       "targets": [
         {
-          "expr": "gpu_gfx_activity{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_busy_percent{hostname=\"$node\"}",
           "refId": "A",
-          "legendFormat": "GFX Activity"
-        },
-        {
-          "expr": "gpu_umc_activity{hostname=\"$node\"}",
-          "refId": "B",
-          "legendFormat": "Memory Activity"
+          "legendFormat": "GPU Busy %"
         }
       ],
       "fieldConfig": {
@@ -1147,7 +1350,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 24,
+        "y": 27,
         "w": 8,
         "h": 8
       }
@@ -1162,19 +1365,9 @@
       },
       "targets": [
         {
-          "expr": "gpu_edge_temperature{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_temperature_celsius{hostname=\"$node\"}",
           "refId": "A",
-          "legendFormat": "Edge"
-        },
-        {
-          "expr": "gpu_junction_temperature{hostname=\"$node\"}",
-          "refId": "B",
-          "legendFormat": "Junction"
-        },
-        {
-          "expr": "gpu_memory_temperature{hostname=\"$node\"}",
-          "refId": "C",
-          "legendFormat": "Memory"
+          "legendFormat": "{{sensor}}"
         }
       ],
       "fieldConfig": {
@@ -1217,7 +1410,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 24,
+        "y": 27,
         "w": 8,
         "h": 8
       }
@@ -1232,14 +1425,14 @@
       },
       "targets": [
         {
-          "expr": "gpu_average_package_power{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_power_watts{hostname=\"$node\",type=\"average\"}",
           "refId": "A",
-          "legendFormat": "Avg Package Power"
+          "legendFormat": "Average"
         },
         {
-          "expr": "gpu_power_usage{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_power_watts{hostname=\"$node\",type=\"instant\"}",
           "refId": "B",
-          "legendFormat": "Power Usage"
+          "legendFormat": "Instant"
         }
       ],
       "fieldConfig": {
@@ -1282,7 +1475,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 32,
+        "y": 35,
         "w": 8,
         "h": 8
       }
@@ -1297,19 +1490,9 @@
       },
       "targets": [
         {
-          "expr": "gpu_gfx_voltage{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_voltage_mv{hostname=\"$node\"}",
           "refId": "A",
-          "legendFormat": "GFX"
-        },
-        {
-          "expr": "gpu_voltage{hostname=\"$node\"}",
-          "refId": "B",
-          "legendFormat": "Core"
-        },
-        {
-          "expr": "gpu_memory_voltage{hostname=\"$node\"}",
-          "refId": "C",
-          "legendFormat": "Memory"
+          "legendFormat": "{{rail}}"
         }
       ],
       "fieldConfig": {
@@ -1352,14 +1535,14 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 32,
+        "y": 35,
         "w": 8,
         "h": 8
       }
     },
     {
       "id": 26,
-      "title": "ECC Errors",
+      "title": "Clocks (MHz)",
       "type": "timeseries",
       "datasource": {
         "type": "prometheus",
@@ -1367,14 +1550,14 @@
       },
       "targets": [
         {
-          "expr": "gpu_ecc_correct_total{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_sclk_mhz{hostname=\"$node\"}",
           "refId": "A",
-          "legendFormat": "Correctable"
+          "legendFormat": "Shader Clock"
         },
         {
-          "expr": "gpu_ecc_uncorrect_total{hostname=\"$node\"}",
+          "expr": "amd_sysfs_gpu_mclk_mhz{hostname=\"$node\"}",
           "refId": "B",
-          "legendFormat": "Uncorrectable"
+          "legendFormat": "Memory Clock"
         }
       ],
       "fieldConfig": {
@@ -1416,7 +1599,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 32,
+        "y": 35,
         "w": 8,
         "h": 8
       }
@@ -1429,7 +1612,7 @@
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 40,
+        "y": 43,
         "w": 24,
         "h": 1
       }
@@ -1494,7 +1677,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 41,
+        "y": 44,
         "w": 24,
         "h": 8
       }
@@ -1507,7 +1690,7 @@
       "panels": [],
       "gridPos": {
         "x": 0,
-        "y": 49,
+        "y": 52,
         "w": 24,
         "h": 1
       }
@@ -1571,7 +1754,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 50,
+        "y": 53,
         "w": 12,
         "h": 8
       }
@@ -1635,7 +1818,7 @@
       },
       "gridPos": {
         "x": 12,
-        "y": 50,
+        "y": 53,
         "w": 12,
         "h": 8
       }

--- a/grafana/deploy.sh
+++ b/grafana/deploy.sh
@@ -66,13 +66,13 @@ run sudo chmod 640 \
     "${GF_PROV}/dashboards/dashboards.yaml"
 
 echo "==> Ensuring dashboard directories exist..."
-for folder in home-network-related general; do
+for folder in home-network-related general amd-related; do
     run sudo mkdir -p "${GF_DASH}/${folder}"
     run sudo chown grafana:grafana "${GF_DASH}/${folder}"
 done
 
 echo "==> Deploying dashboard JSON files..."
-for folder in home-network-related general; do
+for folder in home-network-related general amd-related; do
     src_dir="${SCRIPT_DIR}/dashboards/${folder}"
     [[ -d "${src_dir}" ]] || continue
     for f in "${src_dir}"/*.json; do

--- a/grafana/provisioning/dashboards/dashboards.yaml
+++ b/grafana/provisioning/dashboards/dashboards.yaml
@@ -26,3 +26,14 @@ providers:
     options:
       path: /var/lib/grafana/dashboards/general
       foldersFromFilesStructure: false
+
+  - name: amd-related
+    orgId: 1
+    folder: AMD-Related
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/amd-related
+      foldersFromFilesStructure: false

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -82,6 +82,22 @@ scrape_configs:
           - /etc/prometheus/targets/amd-gpu-metrics-exporter.json
           - /etc/prometheus/targets/discovered/amd-gpu-metrics-exporter.json
         refresh_interval: 30s
+    # Strix Halo APUs: amdsmi cannot read card_model
+    # (ROCm/ROCm#6035). Hardcode it until the library
+    # adds gfx1151 support.
+    metric_relabel_configs:
+      - source_labels: [hostname, card_model]
+        separator: ;
+        regex: 'snoc-strix;'
+        target_label: card_model
+        replacement: 'Radeon 8060S (Strix Halo)'
+
+  - job_name: amd-sysfs-gpu-exporter
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/amd-sysfs-gpu-exporter.json
+          - /etc/prometheus/targets/discovered/amd-sysfs-gpu-exporter.json
+        refresh_interval: 30s
 
   - job_name: ais-exporter
     file_sd_configs:

--- a/prometheus/targets/amd-sysfs-gpu-exporter.json
+++ b/prometheus/targets/amd-sysfs-gpu-exporter.json
@@ -1,0 +1,10 @@
+[
+  {
+    "targets": [
+      "10.0.0.70:9402"
+    ],
+    "labels": {
+      "server_name": "snoc-strix"
+    }
+  }
+]

--- a/prometheus/targets/lemonade-exporter.json
+++ b/prometheus/targets/lemonade-exporter.json
@@ -1,8 +1,18 @@
 [
   {
-    "targets": ["10.0.0.131:9091"],
+    "targets": [
+      "10.0.0.131:9091"
+    ],
     "labels": {
       "server_name": "snoc-thinkstation"
+    }
+  },
+  {
+    "targets": [
+      "10.0.0.70:9091"
+    ],
+    "labels": {
+      "server_name": "snoc-strix"
     }
   }
 ]


### PR DESCRIPTION
Add two lemonade dashboards for monitoring AI inference servers (snoc-strix, snoc-thinkstation):

- A new variable-driven dashboard in General with per-node selection for lemonade metrics, GPU stats, and wall power
- Export and fix the existing "Lemonade: CPU & GPU Monitoring Dashboard" from the AMD-Related folder, switching all GPU queries from the broken amd_gpu_* metrics to the new amd_sysfs_gpu_* exporter

Create amd-sysfs-gpu-exporter, a zero-dependency Python Prometheus exporter that reads AMD GPU metrics directly from sysfs/hwmon. This works around a confirmed amdsmi library limitation on Strix Halo gfx1151 APUs where the official gpuagent reports zeros for temperature, power, clocks, and utilization despite the kernel exposing valid data (ROCm/ROCm#6035). The exporter includes a device ID to model name mapping for Strix Halo SKUs.

Prometheus config changes:
- Add amd-sysfs-gpu-exporter scrape job and target
- Add metric_relabel_configs to fill in empty card_model on Strix Halo for the gpuagent job
- Add snoc-strix to lemonade-exporter targets

Grafana provisioning:
- Add AMD-Related folder to dashboard providers
- Update deploy.sh to handle the new folder

Power plug mapping: snoc-strix uses smartplug H,
snoc-thinkstation uses smartplug D.